### PR TITLE
simplify nix tooling

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ buildRustPackage }:
+buildRustPackage (
+  finalAttrs:
+  let
+    cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  in
+  {
+    pname = "niri-session-manager";
+    src = ./.;
+    inherit (cargoToml.package) version;
+
+    cargoLock = {
+      lockFile = ./Cargo.lock;
+    };
+
+    meta.mainProgram = "niri-session-manager";
+  }
+)

--- a/flake.lock
+++ b/flake.lock
@@ -1,139 +1,62 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1733016477,
-        "narHash": "sha256-Hh0khbqBeCtiNS0SJgqdWrQDem9WlPEc2KF5pAY+st0=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "76d64e779e2fbaf172110038492343a8c4e29b55",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1732689334,
-        "narHash": "sha256-yKI1KiZ0+bvDvfPTQ1ZT3oP/nIu3jPYm4dnbRd6hYg4=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "a8a983027ca02b363dfc82fbe3f7d9548a8d3dce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732824227,
-        "narHash": "sha256-fYNXgpu1AEeLyd3fQt4Ym0tcVP7cdJ8wRoqJ+CtTRyY=",
+        "lastModified": 1749619289,
+        "narHash": "sha256-qX6gXVjaCXXbcn6A9eSLUf8Fm07MgPGe5ir3++y2O1Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c71ad5c34d51dcbda4c15f44ea4e4aa6bb6ac1e9",
+        "rev": "f72be405a10668b8b00937b452f2145244103ebc",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "lastModified": 1749619289,
+        "narHash": "sha256-qX6gXVjaCXXbcn6A9eSLUf8Fm07MgPGe5ir3++y2O1Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f72be405a10668b8b00937b452f2145244103ebc",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "crane": "crane",
-        "devshell": "devshell",
-        "fenix": "fenix",
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "systems": {
       "locked": {
-        "lastModified": 1732633904,
-        "narHash": "sha256-7VKcoLug9nbAN2txqVksWHHJplqK9Ou8dXjIZAIYSGc=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "8d5e91c94f80c257ce6dbdfba7bd63a5e8a03fa6",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1732894027,

--- a/flake.nix
+++ b/flake.nix
@@ -1,167 +1,67 @@
 {
+
   description = "niri-session-manager";
+
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11"; # use stable until crane fix the vscode component pname thingy
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    crane.url = "github:ipetkov/crane";
-    devshell = {
-      url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
   };
-  nixConfig = {
-    extra-substituters = [
-      "https://nix-community.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    ];
-  };
+
   outputs =
-    inputs@{
-      flake-parts,
-      fenix,
-      crane,
-      devshell,
-      treefmt-nix,
+    {
       nixpkgs,
-      ...
+      systems,
+      treefmt-nix,
+      self,
     }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "aarch64-darwin"
-        "x86_64-darwin"
-      ];
-      imports = [
-        devshell.flakeModule
-        treefmt-nix.flakeModule
-      ];
-      flake.nixosModules = {
-        niri-session-manager = {
-          imports = [
-            ./module.nix
-          ];
-          nixpkgs.overlays = [
-            (self: super: {
-              inherit (inputs.self.packages.${super.hostPlatform.system}) niri-session-manager;
-            })
-          ];
-        };
-      };
-      perSystem =
-        {
-          system,
-          config,
-          lib,
-          ...
-        }:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ fenix.overlays.default ];
-          };
-
-          packages = {
-            default = packages.niri-session-manager;
-            niri-session-manager = craneLib.buildPackage build-attrs // {
-              meta.mainProgram = "niri-session-manager";
-            };
-          };
-
-          toolchain =
-            with fenix.packages.${system};
-            combine [
-              latest.rustc
-              latest.cargo
-              latest.clippy
-              latest.rust-analysis
-              latest.rust-src
-              latest.rustfmt
-            ];
-
-          craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
-
-          build-deps = with pkgs; [
-            gcc
-          ];
-
-          unfilteredRoot = ./.; # The original, unfiltered source
-
-          src = lib.fileset.toSource {
-            root = unfilteredRoot;
-            fileset = lib.fileset.unions [
-              # Default files from crane (Rust and cargo files)
-              (craneLib.fileset.commonCargoSources unfilteredRoot)
-              # Keep assets
-              (lib.fileset.maybeMissing ./assets)
-            ];
-          };
-
-          build-attrs = {
-            inherit src;
-            buildInputs = build-deps;
-          };
-
-          deps-only = craneLib.buildDepsOnly ({ } // build-attrs);
-
-          checks = {
-            clippy = craneLib.cargoClippy (
-              {
-                cargoArtifacts = deps-only;
-                cargoClippyExtraArgs = "--all-features -- --deny warnings";
-              }
-              // build-attrs
-            );
-
-            rust-fmt = craneLib.cargoFmt ({ inherit src; } // build-attrs);
-
-            rust-tests = craneLib.cargoNextest (
-              {
-                cargoArtifacts = deps-only;
-                partitions = 1;
-                partitionType = "count";
-              }
-              // build-attrs
-            );
-          };
-
-        in
-        {
-          inherit checks packages;
-          treefmt = {
+    let
+      forAllSystems =
+        function: nixpkgs.lib.genAttrs (import systems) (system: function nixpkgs.legacyPackages.${system});
+      treefmtEval = forAllSystems (
+        pkgs:
+        treefmt-nix.lib.evalModule pkgs (
+          { pkgs, ... }:
+          {
             programs = {
               nixfmt-rfc-style.enable = true;
               statix.enable = true;
             };
-            flakeFormatter = true;
             projectRootFile = "flake.nix";
-          };
+          }
+        )
+      );
+      getPlatform = p: p.hostPlatform.system;
+    in
+    {
+      formatter = forAllSystems (pkgs: treefmtEval.${getPlatform pkgs}.config.build.wrapper);
 
-          devshells.default = {
-            packages =
-              with pkgs;
-              [
-                config.treefmt.build.wrapper
-                # nix formatters
-                nixfmt-rfc-style
-                statix
-                # rust
-                gcc # required for clap
-                toolchain
-              ]
-              ++ build-deps;
-          };
+      checks = forAllSystems (pkgs: {
+        formatting = treefmtEval.${getPlatform pkgs}.config.build.check self;
+      });
 
+      nixosModules = {
+        niri-session-manager =
+          { pkgs, ... }:
+          {
+            imports = [
+              ./module.nix
+            ];
+            services.niri-session-manager.package = self.packages.${getPlatform pkgs}.niri-session-manager;
+          };
+      };
+
+      packages = forAllSystems (pkgs: {
+        default = self.packages.${getPlatform pkgs}.niri-session-manager;
+        niri-session-manager = pkgs.rustPlatform.callPackage ./default.nix { };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = import ./shell.nix { inherit pkgs; };
+      });
+
+      overlays.niri-session-manager = self: super: {
+          inherit (self.packages.${getPlatform super}) niri-session-manager;
         };
     };
 }

--- a/module.nix
+++ b/module.nix
@@ -1,17 +1,24 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
-with lib;
 let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    getExe
+    ;
   cfg = config.services.niri-session-manager;
 in
 {
   options = {
     services.niri-session-manager = {
       enable = mkEnableOption "Niri Session Manager";
+      package = mkPackageOption { } "Niri Session Manager" {
+        nullable = true;
+      };
     };
   };
   config = mkIf cfg.enable {
@@ -25,7 +32,7 @@ in
       serviceConfig = {
         Type = "simple";
         Restart = "always";
-        ExecStart = "${getExe pkgs.niri-session-manager}";
+        ExecStart = "${getExe cfg.package}";
         PrivateTmp = true;
       };
     };

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+pkgs.mkShell {
+  packages = builtins.attrValues {
+    inherit (pkgs) # nix formatters
+      nixfmt-rfc-style
+      statix
+      # rust
+      rustc
+      cargo
+      clippy
+      rust-analyzer
+      rustfmt
+      ;
+  };
+  RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+}


### PR DESCRIPTION
some fixes and tweaks for this project's flake.nix to provide much simpler, lighter packaging. 

- fixed ~850mb of rust tooling leaking into the user's system closure
- removed several flake inputs (see next 5 points)
- replaced flake-parts with a lightweight per-system function to reduce eval time and boilerplate
- removed crane as rust dependencies are light and there is no CI or cache to benefit
- removed fenix as nightly is unnecessary, no unstable features are used
- removed nix-community substituter nixConfig as all toolchain dependencies are now from nixpkgs 
- removed `devshells` input as devshell can be done in flexible and simple fashion already 
- reintegrated treefmt in a simpler way
- integrated nix-systems, providing the default systems as originally specified while allowing users to override them with `follows`
- broke out build / devshell into default.nix / shell.nix for better separation of concerns and non-flake compatibility
- switched `with` usage for attrValues pattern / simple inherits to make scoping explicit
- added package option to module to allow package to be overridden by users
- module now uses own flake outputs directly rather than an overlay; overlaying can involve significant additional evaluation time and is ideally not for package addition so much as systemwide dependency replacement (however, overlay is retained for consumers who prefer or require it)

I have checked it with nix build, develop, check, and fmt - all pass + work as intended.

tl;dr removed boilerplate, input/lockfile bloat, system bloat, reduced nix eval / build times, provided more cache hits for users