### PR TITLE
feat: terminal state recovery via /proc PID resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +260,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -336,6 +364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "niri-ipc"
-version = "0.1.10"
+version = "25.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa541cad3b426dd1ab72765ba71d1c20a1b8a17d80c692b099a759074f74242"
+checksum = "12bd9eb4e437f5282ce853cf66837658379cb537b4b6bae687da59246005329a"
 dependencies = [
  "serde",
  "serde_json",
@@ -389,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "niri-session-manager"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -398,6 +432,7 @@ dependencies = [
  "niri-ipc",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
 ]
@@ -480,6 +515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,7 +535,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -506,16 +547,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
-name = "ryu"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scopeguard"
@@ -525,18 +573,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -545,14 +603,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -610,6 +669,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -712,6 +784,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -942,3 +1023,15 @@ checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "niri-session-manager"
 version = "0.2.0"
@@ -11,7 +9,10 @@ clap = { version = "4.5.21", features = ["derive"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 anyhow = "1.0.94"
-niri-ipc = "=0.1.10"
+niri-ipc = "25.5.1"
 dirs = "5.0"
 chrono = "0.4"
 toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A session manager for the Niri Wayland compositor that automatically saves and r
 - Graceful handling of window spawn failures
 - Configurable retry logic for session restoration
 - Custom app launch command mapping via TOML configuration
+- **Terminal state recovery** — restores running commands inside terminals (e.g. `btop`, `nvim`, `ssh`)
 
 ## Usage
 
@@ -66,9 +67,36 @@ apps = [
 
 # Commands with arguments
 "firefox-custom" = ["firefox", "--profile", "default-release"]
+
+# Terminal state recovery — restore running commands inside terminals
+[terminal_state]
+enabled = true
+terminal_app_ids = ["kitty", "foot", "org.wezfurlong.wezterm", "com.mitchellh.ghostty", "alacritty"]
+shell_names = ["fish", "bash", "zsh", "sh", "dash", "-fish", "-bash", "-zsh", "-sh", "sudo", "doas"]
+helper_names = ["kitten"]
+max_walk_depth = 20
 ```
 
 If no configuration file exists, one will be created with example mappings.
+
+### Terminal State Recovery
+
+When enabled, the session manager walks the process tree of terminal windows via `/proc` to find foreground child processes (skipping shells like `fish`, `bash`, `zsh`). On restore, it re-launches the terminal with the original command and working directory.
+
+For example, if `kitty` was running `btop` in `/home/user/projects`, the restored command becomes:
+
+```bash
+kitty --directory /home/user/projects sh -c "'btop'; exec $SHELL"
+```
+
+Terminal-specific flags are handled automatically:
+- **kitty**: `--directory`, positional command
+- **foot**: `--working-directory`, positional command
+- **wezterm**: `start --cwd ... -- sh -c ...`
+- **ghostty**: `--working-directory=...`, `-e sh -c ...`
+- **alacritty**: `--working-directory`, `-e sh -c ...`
+
+This feature is Linux-only. On other platforms, `terminal_state` is always `None`.
 
 ## Installation
 
@@ -113,8 +141,7 @@ Session data and backups are stored in:
 - Backups: `$XDG_DATA_HOME/niri-session-manager/session-{timestamp}.bak`
 - Configuration: `$XDG_CONFIG_HOME/niri-session-manager/config.toml`
 
-## TODO
-- Use PID to fetch the actual process command
-
 ## Future (when IPC supports it)
 - Grab window size and further details for better placement when restoring windows
+- Configurable per-terminal restore command templates
+- `--dry-run` flag to preview restore without spawning

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ buildRustPackage }:
+{ buildRustPackage, lib }:
 buildRustPackage (
   finalAttrs:
   let
@@ -6,7 +6,18 @@ buildRustPackage (
   in
   {
     pname = "niri-session-manager";
-    src = ./.;
+    src = lib.sources.cleanSourceWith {
+      src = ./.;
+      filter =
+        path: type:
+        type == "directory"
+        || lib.any (ext: lib.hasSuffix ext (baseNameOf path)) [
+          ".rs"
+          ".toml"
+          ".lock"
+          ".nix"
+        ];
+    };
     inherit (cargoToml.package) version;
 
     cargoLock = {

--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,8 @@
         default = import ./shell.nix { inherit pkgs; };
       });
 
-      overlays.niri-session-manager = self: super: {
-          inherit (self.packages.${getPlatform super}) niri-session-manager;
-        };
+      overlays.niri-session-manager = final: prev: {
+        inherit (self.packages.${prev.hostPlatform.system}) niri-session-manager;
+      };
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,56 @@
+mod proc;
+
 use anyhow::{Context, Result};
-use niri_ipc::{Action, Reply, Request, Response, Window, WorkspaceReferenceArg, socket::Socket};
-use std::{fs, path::PathBuf, sync::Arc};
 use chrono::{Local, SecondsFormat};
+use clap::Parser;
+use niri_ipc::{
+    Action, Reply, Request, Response, Window, Workspace, WorkspaceReferenceArg, socket::Socket,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::time::UNIX_EPOCH;
+use std::{
+    fs,
+    path::Path,
+    sync::{Arc, Mutex},
+};
 use tokio::{
     select,
     signal::unix::{SignalKind, signal},
     spawn,
     sync::Notify,
+    task::spawn_blocking,
     time::Duration,
     time::sleep,
 };
-use serde::{Serialize, Deserialize};
-use std::time::{ UNIX_EPOCH};
-use clap::Parser;
-use std::io::Write;
-use std::collections::HashMap;
-use toml;
 
-/// Fetch the windows list
-async fn get_niri_windows() -> Result<Vec<Window>> {
-    let socket = Socket::connect().context("Failed to connect to Niri IPC socket")?;
-    let (reply, _) = socket
-        .send(Request::Windows)
-        .context("Failed to retrieve windows from Niri IPC")?;
-
+async fn niri_send(request: Request) -> Result<Response> {
+    let mut socket = Socket::connect().context("Failed to connect to Niri IPC socket")?;
+    let reply = socket
+        .send(request)
+        .context("Failed to communicate with Niri IPC")?;
     match reply {
-        Reply::Ok(Response::Windows(windows)) => Ok(windows),
+        Reply::Ok(response) => Ok(response),
         Reply::Err(error_msg) => anyhow::bail!("Niri IPC returned an error: {}", error_msg),
-        _ => anyhow::bail!("Unexpected reply type from Niri"),
     }
 }
 
-/// fetch the session file path
-fn get_session_file_path() -> Result<PathBuf> {
+async fn get_niri_windows() -> Result<Vec<Window>> {
+    match niri_send(Request::Windows).await? {
+        Response::Windows(windows) => Ok(windows),
+        _ => anyhow::bail!("Expected Windows response from Niri"),
+    }
+}
+
+async fn get_niri_workspaces() -> Result<Vec<Workspace>> {
+    match niri_send(Request::Workspaces).await? {
+        Response::Workspaces(workspaces) => Ok(workspaces),
+        _ => anyhow::bail!("Expected Workspaces response from Niri"),
+    }
+}
+
+fn get_session_file_path() -> Result<std::path::PathBuf> {
     let mut session_dir =
         dirs::data_dir().context("Failed to locate data directory (XDG_DATA_HOME)")?;
     session_dir.push("niri-session-manager");
@@ -40,47 +58,82 @@ fn get_session_file_path() -> Result<PathBuf> {
     Ok(session_dir.join("session.json"))
 }
 
-// Define a struct that doesn't include the `title` field
-#[derive(Serialize, Deserialize)]
-struct WindowWithoutTitle {
+#[derive(Debug, Serialize, Deserialize)]
+struct SavedWindow {
     id: u64,
     app_id: String,
-    workspace_id: Option<u64>,
+    #[serde(default)]
+    workspace_idx: Option<u8>,
+    #[serde(default)]
+    workspace_name: Option<String>,
+    #[serde(default)]
+    workspace_output: Option<String>,
     is_focused: bool,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    terminal_state: Option<TerminalState>,
+    #[serde(default, skip_serializing)]
+    workspace_id: Option<u64>,
 }
 
-/// Save the session to a file
-async fn save_session(file_path: &PathBuf) -> Result<()> {
-    let windows = get_niri_windows().await?;
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+enum ChildCommand {
+    Args(Vec<String>),
+    Legacy(String),
+}
 
-    // Create a new list of windows without the `title` field
-    let windows_without_title: Vec<WindowWithoutTitle> = windows.into_iter().map(|window| {
-        WindowWithoutTitle {
-            id: window.id,
-            app_id: window.app_id.unwrap_or_default(),
-            workspace_id: window.workspace_id,
-            is_focused: window.is_focused,
+impl ChildCommand {
+    fn to_args(&self) -> Vec<String> {
+        match self {
+            ChildCommand::Args(args) => args.clone(),
+            ChildCommand::Legacy(s) => s.split_whitespace().map(String::from).collect(),
         }
-    }).collect();
-
-//    let json_data = serde_json::to_string_pretty(&windows).context("Failed to serialize window data")?;
-    // Serialize the modified windows list to JSON
-    let json_data = serde_json::to_string_pretty(&windows_without_title)
-        .context("Failed to serialize window data")?;
-
-    fs::write(file_path, json_data).context("Failed to write session file")?;
-    log(&format!("Session saved to {}", file_path.display()));
-    Ok(())
+    }
 }
 
-/// Restore saved session with retry logic
-async fn restore_session(file_path: &PathBuf, config: &Config) -> Result<()> {
+#[derive(Debug, Serialize, Deserialize)]
+struct TerminalState {
+    child_command: Option<ChildCommand>,
+    child_cwd: Option<String>,
+}
+
+const SESSION_FORMAT_VERSION: u32 = 3;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct VersionedSession {
+    version: u32,
+    windows: Vec<SavedWindow>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SessionData {
+    Versioned(VersionedSession),
+    Legacy(Vec<SavedWindow>),
+}
+
+impl SessionData {
+    fn into_windows(self) -> Vec<SavedWindow> {
+        match self {
+            SessionData::Versioned(v) => v.windows,
+            SessionData::Legacy(windows) => windows,
+        }
+    }
+
+    fn is_legacy(&self) -> bool {
+        matches!(self, SessionData::Legacy(_))
+    }
+}
+
+async fn restore_session(file_path: &Path, config: &Config) -> Result<()> {
     for attempt in 1..=config.retry_attempts {
         match restore_session_internal(file_path, config).await {
             Ok(_) => return Ok(()),
             Err(e) if attempt < config.retry_attempts => {
                 eprintln!(
-                    "Attempt {} failed: {}. Retrying in {} seconds...", 
+                    "Attempt {} failed: {}. Retrying in {} seconds...",
                     attempt, e, config.retry_delay
                 );
                 sleep(Duration::from_secs(config.retry_delay)).await;
@@ -91,15 +144,64 @@ async fn restore_session(file_path: &PathBuf, config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// App launch configuration
+fn default_enabled() -> bool {
+    true
+}
+fn default_terminal_app_ids() -> Vec<String> {
+    vec![
+        "kitty".into(),
+        "foot".into(),
+        "org.wezfurlong.wezterm".into(),
+        "com.mitchellh.ghostty".into(),
+        "alacritty".into(),
+    ]
+}
+fn default_shell_names() -> Vec<String> {
+    vec![
+        "fish".into(),
+        "bash".into(),
+        "zsh".into(),
+        "sh".into(),
+        "dash".into(),
+        "-fish".into(),
+        "-bash".into(),
+        "-zsh".into(),
+        "-sh".into(),
+        "sudo".into(),
+        "doas".into(),
+    ]
+}
+fn default_helper_names() -> Vec<String> {
+    vec!["kitten".into()]
+}
+fn default_max_walk_depth() -> u32 {
+    20
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct AppConfig {
-    #[serde(default)]
-    app_mappings: HashMap<String, Vec<String>>,
-    #[serde(default, rename = "single_instance_apps")]
-    single_instance: SingleInstanceAppsConfig,
-    #[serde(default, rename = "skip_apps")]
-    skip_apps: SkipAppsConfig, // New field to hold apps to skip
+struct TerminalStateConfig {
+    #[serde(default = "default_enabled")]
+    enabled: bool,
+    #[serde(default = "default_terminal_app_ids")]
+    terminal_app_ids: Vec<String>,
+    #[serde(default = "default_shell_names")]
+    shell_names: Vec<String>,
+    #[serde(default = "default_helper_names")]
+    helper_names: Vec<String>,
+    #[serde(default = "default_max_walk_depth")]
+    max_walk_depth: u32,
+}
+
+impl Default for TerminalStateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            terminal_app_ids: default_terminal_app_ids(),
+            shell_names: default_shell_names(),
+            helper_names: default_helper_names(),
+            max_walk_depth: default_max_walk_depth(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -114,27 +216,28 @@ struct SkipAppsConfig {
     apps: Vec<String>,
 }
 
-impl Default for AppConfig {
-    fn default() -> Self {
-        Self {
-            app_mappings: HashMap::new(),
-            single_instance: SingleInstanceAppsConfig::default(),
-            skip_apps: SkipAppsConfig::default(), 
-        }
-    }
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct AppConfig {
+    #[serde(default)]
+    app_mappings: HashMap<String, Vec<String>>,
+    #[serde(default, rename = "single_instance_apps")]
+    single_instance: SingleInstanceAppsConfig,
+    #[serde(default, rename = "skip_apps")]
+    skip_apps: SkipAppsConfig,
+    #[serde(default)]
+    terminal_state: TerminalStateConfig,
 }
 
-/// Load app configuration from TOML file
 fn load_app_config() -> Result<AppConfig> {
-    let mut config_path = dirs::config_dir()
-        .context("Failed to locate config directory")?;
+    let mut config_path = dirs::config_dir().context("Failed to locate config directory")?;
     config_path.push("niri-session-manager");
     config_path.push("config.toml");
 
     if !config_path.exists() {
-        // Create default config if it doesn't exist
         fs::create_dir_all(config_path.parent().unwrap())?;
-        fs::write(&config_path, r#"# Niri Session Manager Configuration
+        fs::write(
+            &config_path,
+            r#"# Niri Session Manager Configuration
 
 # Apps that should only have one instance
 [single_instance_apps] 
@@ -158,27 +261,278 @@ apps = [
 
 # Commands with arguments
 "firefox-custom" = ["firefox", "--profile", "default-release"]
-"#)?;
+
+# Terminal state recovery — restore running commands inside terminals
+[terminal_state]
+enabled = true
+terminal_app_ids = ["kitty", "foot", "org.wezfurlong.wezterm", "com.mitchellh.ghostty", "alacritty"]
+shell_names = ["fish", "bash", "zsh", "sh", "dash", "-fish", "-bash", "-zsh", "-sh", "sudo", "doas"]
+helper_names = ["kitten"]
+max_walk_depth = 20
+"#,
+        )?;
         return Ok(AppConfig::default());
     }
 
-    let config_str = fs::read_to_string(&config_path)
-        .context("Failed to read config file")?;
-    
-    let config: AppConfig = toml::from_str(&config_str)
-        .context("Failed to parse config file")?;
-    //log(&format!("Single-instance apps: {:?}", config.single_instance.apps));
-    //log(&format!("Loaded configuration with {} app mappings", config.app_mappings.len()));
-    //log(&format!("{:?} app mappings", config.app_mappings));
+    let config_str = fs::read_to_string(&config_path).context("Failed to read config file")?;
+
+    let config: AppConfig = toml::from_str(&config_str).context("Failed to parse config file")?;
     Ok(config)
 }
 
-/// Update restore_session_internal to use app mappings
-async fn restore_session_internal(file_path: &PathBuf, config: &Config) -> Result<()> {
+fn shell_escape(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(target_os = "linux")]
+fn get_shell_from_passwd() -> Option<String> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    let uid_line = status.lines().find(|l| l.starts_with("Uid:"))?;
+    let uid = uid_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse::<u32>().ok())?;
+
+    let passwd = fs::read_to_string("/etc/passwd").ok()?;
+    for line in passwd.lines() {
+        let fields: Vec<&str> = line.split(':').collect();
+        if fields.len() >= 7 && fields[2].parse::<u32>().ok() == Some(uid) {
+            let shell = fields[6].trim();
+            if !shell.is_empty() {
+                return Some(shell.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn get_restore_shell() -> String {
+    if let Ok(shell) = std::env::var("SHELL")
+        && !shell.is_empty()
+    {
+        return shell;
+    }
+    #[cfg(target_os = "linux")]
+    if let Some(shell) = get_shell_from_passwd() {
+        return shell;
+    }
+    "/bin/sh".to_string()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CwdFlag {
+    Separated(&'static str),
+    Joined(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalProfile {
+    Kitty,
+    Foot,
+    Wezterm,
+    Ghostty,
+    Alacritty,
+    Generic,
+}
+
+impl TerminalProfile {
+    fn from_executable(name: &str) -> Self {
+        match name {
+            "kitty" => Self::Kitty,
+            "foot" => Self::Foot,
+            "wezterm" => Self::Wezterm,
+            "ghostty" => Self::Ghostty,
+            "alacritty" => Self::Alacritty,
+            _ => Self::Generic,
+        }
+    }
+
+    fn needs_start_subcommand(&self) -> bool {
+        matches!(self, Self::Wezterm)
+    }
+
+    fn cwd_flag(&self) -> CwdFlag {
+        match self {
+            Self::Kitty => CwdFlag::Separated("--directory"),
+            Self::Foot => CwdFlag::Separated("--working-directory"),
+            Self::Wezterm => CwdFlag::Separated("--cwd"),
+            Self::Ghostty => CwdFlag::Joined("--working-directory="),
+            Self::Alacritty | Self::Generic => CwdFlag::Separated("--working-directory"),
+        }
+    }
+
+    fn cmd_flag(&self) -> Option<&'static str> {
+        match self {
+            Self::Kitty | Self::Foot => None,
+            Self::Wezterm => Some("--"),
+            Self::Ghostty | Self::Alacritty | Self::Generic => Some("-e"),
+        }
+    }
+}
+
+fn resolve_executable_name(app_id: &str, app_mappings: &HashMap<String, Vec<String>>) -> String {
+    app_mappings
+        .get(app_id)
+        .and_then(|args| args.first())
+        .cloned()
+        .unwrap_or_else(|| app_id.to_string())
+}
+
+fn build_terminal_restore_command(
+    launch_prefix: &[String],
+    profile: &TerminalProfile,
+    child_cmd: &[String],
+    child_cwd: &Option<String>,
+) -> Vec<String> {
+    let mut cmd: Vec<String> = launch_prefix.to_vec();
+
+    if profile.needs_start_subcommand() {
+        cmd.push("start".to_string());
+    }
+
+    let cwd_flag = child_cwd
+        .as_ref()
+        .filter(|cwd| !cwd.is_empty() && **cwd != std::env::var("HOME").unwrap_or_default());
+
+    if let Some(cwd) = cwd_flag {
+        match profile.cwd_flag() {
+            CwdFlag::Separated(flag) => {
+                cmd.push(flag.to_string());
+                cmd.push(cwd.clone());
+            }
+            CwdFlag::Joined(flag) => {
+                cmd.push(format!("{}{}", flag, cwd));
+            }
+        }
+    }
+
+    if let Some(flag) = profile.cmd_flag() {
+        cmd.push(flag.to_string());
+    }
+
+    let escaped_cmd: String = child_cmd
+        .iter()
+        .map(|arg| shell_escape(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let restore_shell = get_restore_shell();
+    cmd.push("sh".to_string());
+    cmd.push("-c".to_string());
+    cmd.push(format!(
+        "{}; exec {}",
+        escaped_cmd,
+        shell_escape(&restore_shell)
+    ));
+
+    cmd
+}
+
+fn build_spawn_command(
+    app_id: &str,
+    saved_window: &SavedWindow,
+    app_mappings: &HashMap<String, Vec<String>>,
+) -> Vec<String> {
+    let mapped = app_mappings
+        .get(app_id)
+        .cloned()
+        .unwrap_or_else(|| vec![app_id.to_string()]);
+
+    if let Some(ts) = &saved_window.terminal_state
+        && let Some(child_cmd) = &ts.child_command
+    {
+        let args = child_cmd.to_args();
+        if !args.is_empty() {
+            let exec_name = resolve_executable_name(app_id, app_mappings);
+            let profile = TerminalProfile::from_executable(&exec_name);
+            return build_terminal_restore_command(&mapped, &profile, &args, &ts.child_cwd);
+        }
+    }
+
+    mapped
+}
+
+async fn resolve_terminal_state(
+    pid: u32,
+    config: &TerminalStateConfig,
+) -> Option<(Vec<String>, String)> {
+    let shell_names = config.shell_names.clone();
+    let helper_names = config.helper_names.clone();
+    let max_depth = config.max_walk_depth;
+    spawn_blocking(move || proc::resolve_child_process(pid, &shell_names, &helper_names, max_depth))
+        .await
+        .ok()
+        .flatten()
+}
+
+async fn save_session_with_terminal_state(file_path: &Path, app_config: &AppConfig) -> Result<()> {
+    let windows = get_niri_windows().await?;
+    let workspaces = get_niri_workspaces().await?;
+    let terminal_config = &app_config.terminal_state;
+
+    let mut saved_windows = Vec::with_capacity(windows.len());
+
+    for window in &windows {
+        let ws = workspaces
+            .iter()
+            .find(|w| window.workspace_id == Some(w.id));
+        let app_id = window.app_id.clone().unwrap_or_default();
+        let pid = window
+            .pid
+            .and_then(|p| if p > 0 { Some(p as u32) } else { None });
+
+        let terminal_state = if terminal_config.enabled {
+            match pid {
+                Some(pid) if terminal_config.terminal_app_ids.contains(&app_id) => {
+                    resolve_terminal_state(pid, terminal_config).await.map(
+                        |(child_command, child_cwd)| TerminalState {
+                            child_command: Some(ChildCommand::Args(child_command)),
+                            child_cwd: Some(child_cwd),
+                        },
+                    )
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        saved_windows.push(SavedWindow {
+            id: window.id,
+            app_id: app_id.clone(),
+            workspace_idx: ws.map(|w| w.idx),
+            workspace_name: ws.and_then(|w| w.name.clone()),
+            workspace_output: ws.and_then(|w| w.output.clone()),
+            is_focused: window.is_focused,
+            pid,
+            terminal_state,
+            workspace_id: None,
+        });
+    }
+
+    let session = VersionedSession {
+        version: SESSION_FORMAT_VERSION,
+        windows: saved_windows,
+    };
+    let json_data =
+        serde_json::to_string_pretty(&session).context("Failed to serialize window data")?;
+
+    fs::write(file_path, json_data).context("Failed to write session file")?;
+    log(&format!("Session saved to {}", file_path.display()));
+    Ok(())
+}
+
+async fn restore_session_internal(file_path: &Path, config: &Config) -> Result<()> {
     if !file_path.exists() {
-        log(&format!("No previous session found at {}", file_path.display()));
+        log(&format!(
+            "No previous session found at {}",
+            file_path.display()
+        ));
         log("Building new session file");
-        save_session(&file_path).await?;
+        let app_config = load_app_config()?;
+        save_session_with_terminal_state(file_path, &app_config).await?;
         return Ok(());
     }
 
@@ -187,33 +541,48 @@ async fn restore_session_internal(file_path: &PathBuf, config: &Config) -> Resul
         log(&format!("Session file at {} is empty", file_path.display()));
         return Ok(());
     }
-    let windows: Vec<Window> =
+    let session: SessionData =
         serde_json::from_str(&session_data).context("Failed to parse session JSON")?;
+    if session.is_legacy() {
+        log(
+            "Warning: session file uses legacy format (no version field). Consider re-saving to upgrade.",
+        );
+    }
+    let mut saved_windows = session.into_windows();
+    let has_legacy_workspace_id = saved_windows.iter().any(|w| w.workspace_id.is_some());
+    if has_legacy_workspace_id {
+        log(
+            "Warning: session file contains deprecated 'workspace_id' field. Workspace info was lost. Re-save to upgrade format.",
+        );
+    }
+    saved_windows.sort_by_key(|w| w.workspace_idx.unwrap_or(0));
 
     let current_windows = get_niri_windows().await?;
+    let claimed_window_ids: Arc<Mutex<HashSet<u64>>> =
+        Arc::new(Mutex::new(current_windows.iter().map(|w| w.id).collect()));
     let mut handles = Vec::new();
 
-    // Load app configuration
     let app_config = load_app_config()?;
 
-    let mut spawned_apps = std::collections::HashSet::new();
-    
-    for window in windows {
+    let mut spawned_apps = HashSet::new();
 
-        let app_id = window.app_id.clone().unwrap_or_default();
+    for saved_window in saved_windows {
+        let app_id = saved_window.app_id.clone();
 
-            // Check if the app should be skipped
         if app_config.skip_apps.apps.contains(&app_id) {
             log(&format!("Skipping app: {}", app_id));
-            continue; // Skip this app
+            continue;
         }
 
-        let should_skip = current_windows.iter().any(|w| w.app_id == Some(app_id.clone()))
+        let should_skip = current_windows
+            .iter()
+            .any(|w| w.app_id == Some(app_id.clone()))
             || spawned_apps.contains(&app_id);
-        
-        let workspace_id = window.workspace_id;
 
-        // Check if app is single-instance and already running
+        let workspace_idx = saved_window.workspace_idx;
+        let workspace_name = saved_window.workspace_name.clone();
+        let workspace_output = saved_window.workspace_output.clone();
+
         if app_config.single_instance.apps.contains(&app_id) && should_skip {
             log(&format!("Skipping single-instance app: {}", app_id));
             continue;
@@ -223,46 +592,78 @@ async fn restore_session_internal(file_path: &PathBuf, config: &Config) -> Resul
             spawned_apps.insert(app_id.clone());
         }
 
-        // Get command from app mappings or use app_id as fallback
-        let command = app_config.app_mappings
-            .get(&app_id)
-            .cloned()
-            .unwrap_or_else(|| vec![app_id.clone()]);
+        let command = build_spawn_command(&app_id, &saved_window, &app_config.app_mappings);
 
         let spawn_timeout = config.spawn_timeout;
+        let claimed_window_ids = Arc::clone(&claimed_window_ids);
         let handle = spawn(async move {
-            let spawn_socket = Socket::connect().context("Failed to connect to Niri IPC socket")?;
-            let (reply, _) = spawn_socket
+            let mut spawn_socket =
+                Socket::connect().context("Failed to connect to Niri IPC socket")?;
+            let reply = spawn_socket
                 .send(Request::Action(Action::Spawn {
                     command: command.clone(),
                 }))
                 .context("Failed to send spawn request")?;
 
             if let Reply::Ok(Response::Handled) = reply {
-                // Use configured spawn timeout
                 for _ in 0..spawn_timeout * 2 {
                     sleep(Duration::from_millis(500)).await;
                     let new_windows = get_niri_windows().await?;
-                    if let Some(new_window) = new_windows
-                        .iter()
-                        .find(|w| w.app_id == Some(app_id.clone()))
-                    {
-                        let move_socket =
+                    let win_id = {
+                        let mut claimed = claimed_window_ids.lock().unwrap();
+                        new_windows
+                            .iter()
+                            .find(|w| w.app_id == Some(app_id.clone()) && !claimed.contains(&w.id))
+                            .map(|w| {
+                                claimed.insert(w.id);
+                                w.id
+                            })
+                    };
+                    if let Some(win_id) = win_id {
+                        let mut move_socket =
                             Socket::connect().context("Failed to connect to Niri IPC socket")?;
-                        let _ = move_socket
-                            .send(Request::Action(Action::MoveWindowToWorkspace {
-                                window_id: Some(new_window.id),
-                                reference: WorkspaceReferenceArg::Id(
-                                    workspace_id.unwrap_or_default(),
-                                ),
+
+                        if let Some(output) = &workspace_output {
+                            let result =
+                                move_socket.send(Request::Action(Action::MoveWindowToMonitor {
+                                    id: Some(win_id),
+                                    output: output.clone(),
+                                }));
+                            if let Err(e) = &result {
+                                log_error(&format!(
+                                    "Warning: failed to move window {} to monitor {}: {:?}",
+                                    win_id, output, e
+                                ));
+                            }
+                        }
+
+                        let workspace_reference =
+                            if let Some(name) = workspace_name.as_ref().filter(|n| !n.is_empty()) {
+                                WorkspaceReferenceArg::Name(name.clone())
+                            } else {
+                                WorkspaceReferenceArg::Index(workspace_idx.unwrap_or(0))
+                            };
+
+                        if let Err(e) =
+                            move_socket.send(Request::Action(Action::MoveWindowToWorkspace {
+                                window_id: Some(win_id),
+                                reference: workspace_reference,
+                                focus: false,
                             }))
-                            .context("Failed to move window to the workspace")?;
+                        {
+                            log_error(&format!(
+                                "Warning: failed to move window {} to workspace: {:?}",
+                                win_id, e
+                            ));
+                        }
                         break;
                     }
                 }
             } else {
-                log(&format!("Failed to spawn app: {} using command: {:?}", 
-                    app_id, command));
+                log(&format!(
+                    "Failed to spawn app: {} using command: {:?}",
+                    app_id, command
+                ));
             }
 
             Result::<()>::Ok(())
@@ -271,19 +672,14 @@ async fn restore_session_internal(file_path: &PathBuf, config: &Config) -> Resul
         handles.push(handle);
     }
 
-    // Wait for all tasks to complete.
     for handle in handles {
         handle.await.context("Task execution failed")??;
     }
 
     log("Session restored.");
-    // Clean up the session file after restoring.
-    //fs::remove_file(file_path).context("Failed to delete session file")?;
-    //println!("Session file cleaned up.");
     Ok(())
 }
 
-/// Handle shutdown signals and notify the main function.
 async fn handle_shutdown_signals(shutdown_signal: Arc<Notify>) {
     let mut term_signal = signal(SignalKind::terminate()).expect("Failed to listen for SIGTERM");
     let mut int_signal = signal(SignalKind::interrupt()).expect("Failed to listen for SIGINT");
@@ -305,16 +701,18 @@ async fn handle_shutdown_signals(shutdown_signal: Arc<Notify>) {
     }
 }
 
-/// Periodically save the session based on configured interval
 async fn periodic_save_session(
-    file_path: PathBuf,
+    file_path: std::path::PathBuf,
     shutdown_signal: Arc<Notify>,
-    config: Config
+    config: Config,
 ) {
-    let interval = Duration::from_secs(config.save_interval * 60); // Convert minutes to seconds
+    let interval = Duration::from_secs(config.save_interval * 60);
     let session_dir = file_path.parent().unwrap_or(&file_path).to_path_buf();
 
-    log(&format!("Starting periodic save task (interval: {} minutes)", config.save_interval));
+    log(&format!(
+        "Starting periodic save task (interval: {} minutes)",
+        config.save_interval
+    ));
 
     loop {
         select! {
@@ -322,7 +720,6 @@ async fn periodic_save_session(
                 if let Err(e) = save_session_with_backup(&file_path, &config).await {
                     log_error(&format!("Error saving session: {}", e));
                 }
-                // Cleanup old backups after each save
                 if let Err(e) = cleanup_old_backups(&session_dir, config.max_backup_count) {
                     log_error(&format!("Error cleaning up old backups: {}", e));
                 }
@@ -340,19 +737,18 @@ async fn periodic_save_session(
     }
 }
 
-async fn save_session_with_backup(file_path: &PathBuf, config: &Config) -> Result<()> {
+async fn save_session_with_backup(file_path: &Path, config: &Config) -> Result<()> {
     create_backup(file_path)?;
-    
-    // Cleanup old backups after creating a new one
+
     if let Some(session_dir) = file_path.parent() {
-        cleanup_old_backups(&session_dir.to_path_buf(), config.max_backup_count)?;
+        cleanup_old_backups(session_dir, config.max_backup_count)?;
     }
-    
-    save_session(file_path).await
+
+    let app_config = load_app_config()?;
+    save_session_with_terminal_state(file_path, &app_config).await
 }
 
-/// Create a timestamped backup of the file
-fn create_backup(file_path: &PathBuf) -> Result<()> {
+fn create_backup(file_path: &Path) -> Result<()> {
     if file_path.exists() {
         let timestamp = Local::now().to_rfc3339_opts(SecondsFormat::Secs, true);
         let backup_file_name = format!(
@@ -360,7 +756,7 @@ fn create_backup(file_path: &PathBuf) -> Result<()> {
             file_path.file_stem().unwrap_or_default().to_string_lossy(),
             timestamp
         );
-        let mut backup_path = file_path.clone();
+        let mut backup_path = file_path.to_path_buf();
         backup_path.set_file_name(backup_file_name);
         fs::copy(file_path, &backup_path).context("Failed to create backup file")?;
         log(&format!("Backup created at {}", backup_path.display()));
@@ -368,25 +764,23 @@ fn create_backup(file_path: &PathBuf) -> Result<()> {
     Ok(())
 }
 
-/// Clean up old backup files, keeping only the most recent N backups
-fn cleanup_old_backups(session_dir: &PathBuf, keep_count: usize) -> Result<()> {
-    // Get all backup files
+fn cleanup_old_backups(session_dir: &Path, keep_count: usize) -> Result<()> {
     let mut backups: Vec<_> = fs::read_dir(session_dir)?
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            entry.path()
+            entry
+                .path()
                 .file_name()
                 .and_then(|n| n.to_str())
                 .map(|n| n.ends_with(".bak"))
                 .unwrap_or(false)
         })
         .collect();
-    
+
     if backups.len() <= keep_count {
         return Ok(());
     }
 
-    // Sort by modification time, newest first
     backups.sort_by(|a, b| {
         b.metadata()
             .and_then(|m| m.modified())
@@ -394,15 +788,17 @@ fn cleanup_old_backups(session_dir: &PathBuf, keep_count: usize) -> Result<()> {
             .cmp(
                 &a.metadata()
                     .and_then(|m| m.modified())
-                    .unwrap_or(UNIX_EPOCH)
+                    .unwrap_or(UNIX_EPOCH),
             )
     });
 
-    // Remove older backups
     for backup in backups.iter().skip(keep_count) {
         if let Err(e) = fs::remove_file(backup.path()) {
-            log_error(&format!("Failed to remove old backup {}: {}", 
-                backup.path().display(), e));
+            log_error(&format!(
+                "Failed to remove old backup {}: {}",
+                backup.path().display(),
+                e
+            ));
         } else {
             log(&format!("Removed old backup: {}", backup.path().display()));
         }
@@ -411,38 +807,30 @@ fn cleanup_old_backups(session_dir: &PathBuf, keep_count: usize) -> Result<()> {
     Ok(())
 }
 
-/// CLI Arguments for niri-session-manager
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 struct Config {
-    /// Save interval in minutes
     #[arg(long, default_value = "15")]
     save_interval: u64,
 
-    /// Maximum number of backup files to keep
     #[arg(long, default_value = "5")]
     max_backup_count: usize,
 
-    /// Timeout in seconds when spawning windows
     #[arg(long, default_value = "5")]
     spawn_timeout: u64,
 
-    /// Number of restore attempts
     #[arg(long, default_value = "3")]
     retry_attempts: u32,
 
-    /// Delay between retry attempts in seconds
     #[arg(long, default_value = "2")]
     retry_delay: u64,
 }
 
-// Update log function to handle format strings
 fn log(message: &str) {
     println!("{message}");
     std::io::stdout().flush().unwrap_or_default();
 }
 
-// Update error logging
 fn log_error(message: &str) {
     eprintln!("{}", message);
     std::io::stderr().flush().unwrap_or_default();
@@ -450,32 +838,27 @@ fn log_error(message: &str) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Parse command line arguments
     let config = Config::parse();
-    
+
     log("Starting niri-session-manager");
     let session_file_path = get_session_file_path()?;
     let shutdown_signal = Arc::new(Notify::new());
 
-    // Start the periodic save task with config
     let shutdown_signal_clone = Arc::clone(&shutdown_signal);
     let save_task = spawn(periodic_save_session(
         session_file_path.clone(),
         shutdown_signal_clone,
-        config.clone()
+        config.clone(),
     ));
 
-    // Restore session with config
     log("Restoring previous session");
     restore_session(&session_file_path, &config).await?;
-    
+
     let shutdown_signal_clone = Arc::clone(&shutdown_signal);
     let signal_task = spawn(handle_shutdown_signals(shutdown_signal_clone));
 
-    // Wait for shutdown signal and tasks to complete
     shutdown_signal.notified().await;
-    
-    // Wait for tasks to finish with timeout
+
     let timeout = Duration::from_secs(5);
     select! {
         _ = save_task => log("Save task completed"),
@@ -485,4 +868,518 @@ async fn main() -> Result<()> {
 
     log("Shutdown complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expected_exec_suffix(child_cmd: &str) -> String {
+        let shell = get_restore_shell();
+        format!("{}; exec {}", shell_escape(child_cmd), shell_escape(&shell))
+    }
+
+    #[test]
+    fn shell_escape_empty() {
+        assert_eq!(shell_escape(""), "''");
+    }
+
+    #[test]
+    fn shell_escape_simple() {
+        assert_eq!(shell_escape("btop"), "'btop'");
+    }
+
+    #[test]
+    fn shell_escape_with_spaces() {
+        assert_eq!(shell_escape("nvim /path/to file"), "'nvim /path/to file'");
+    }
+
+    #[test]
+    fn shell_escape_with_single_quotes() {
+        assert_eq!(shell_escape("echo 'hello'"), "'echo '\\''hello'\\'''");
+    }
+
+    #[test]
+    fn shell_escape_with_semicolons() {
+        assert_eq!(shell_escape("cmd; rm -rf /"), "'cmd; rm -rf /'");
+    }
+
+    #[test]
+    fn shell_escape_with_dollar() {
+        assert_eq!(shell_escape("echo $HOME"), "'echo $HOME'");
+    }
+
+    #[test]
+    fn shell_escape_with_backticks() {
+        assert_eq!(shell_escape("echo `whoami`"), "'echo `whoami`'");
+    }
+
+    #[test]
+    fn resolve_executable_from_mappings() {
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "com.mitchellh.ghostty".to_string(),
+            vec!["ghostty".to_string()],
+        );
+        mappings.insert(
+            "org.wezfurlong.wezterm".to_string(),
+            vec!["wezterm".to_string()],
+        );
+
+        assert_eq!(
+            resolve_executable_name("com.mitchellh.ghostty", &mappings),
+            "ghostty"
+        );
+        assert_eq!(
+            resolve_executable_name("org.wezfurlong.wezterm", &mappings),
+            "wezterm"
+        );
+        assert_eq!(resolve_executable_name("kitty", &mappings), "kitty");
+        assert_eq!(resolve_executable_name("unknown", &mappings), "unknown");
+    }
+
+    #[test]
+    fn terminal_profile_kitty() {
+        let p = TerminalProfile::from_executable("kitty");
+        assert!(!p.needs_start_subcommand());
+        assert_eq!(p.cwd_flag(), CwdFlag::Separated("--directory"));
+        assert_eq!(p.cmd_flag(), None);
+    }
+
+    #[test]
+    fn terminal_profile_foot() {
+        let p = TerminalProfile::from_executable("foot");
+        assert!(!p.needs_start_subcommand());
+        assert_eq!(p.cwd_flag(), CwdFlag::Separated("--working-directory"));
+        assert_eq!(p.cmd_flag(), None);
+    }
+
+    #[test]
+    fn terminal_profile_wezterm() {
+        let p = TerminalProfile::from_executable("wezterm");
+        assert!(p.needs_start_subcommand());
+        assert_eq!(p.cwd_flag(), CwdFlag::Separated("--cwd"));
+        assert_eq!(p.cmd_flag(), Some("--"));
+    }
+
+    #[test]
+    fn terminal_profile_ghostty() {
+        let p = TerminalProfile::from_executable("ghostty");
+        assert!(!p.needs_start_subcommand());
+        assert_eq!(p.cwd_flag(), CwdFlag::Joined("--working-directory="));
+        assert_eq!(p.cmd_flag(), Some("-e"));
+    }
+
+    #[test]
+    fn terminal_profile_alacritty() {
+        let p = TerminalProfile::from_executable("alacritty");
+        assert!(!p.needs_start_subcommand());
+        assert_eq!(p.cwd_flag(), CwdFlag::Separated("--working-directory"));
+        assert_eq!(p.cmd_flag(), Some("-e"));
+    }
+
+    #[test]
+    fn terminal_profile_generic() {
+        let p = TerminalProfile::from_executable("unknown-terminal");
+        assert!(!p.needs_start_subcommand());
+        assert_eq!(p.cwd_flag(), CwdFlag::Separated("--working-directory"));
+        assert_eq!(p.cmd_flag(), Some("-e"));
+    }
+
+    fn assert_restore_command(cmd: &[String], expected_prefix: &[&str], child_cmd: &str) {
+        for (i, expected) in expected_prefix.iter().enumerate() {
+            assert_eq!(cmd[i], *expected);
+        }
+        assert_eq!(cmd[expected_prefix.len()], expected_exec_suffix(child_cmd));
+    }
+
+    #[test]
+    fn build_restore_kitty_with_cwd() {
+        let profile = TerminalProfile::Kitty;
+        let cmd = build_terminal_restore_command(
+            &["kitty".to_string()],
+            &profile,
+            &["btop".to_string()],
+            &Some("/home/user/projects".to_string()),
+        );
+        assert_restore_command(
+            &cmd,
+            &["kitty", "--directory", "/home/user/projects", "sh", "-c"],
+            "btop",
+        );
+    }
+
+    #[test]
+    fn build_restore_kitty_without_cwd() {
+        let profile = TerminalProfile::Kitty;
+        let home = std::env::var("HOME").unwrap_or_default();
+        let cmd = build_terminal_restore_command(
+            &["kitty".to_string()],
+            &profile,
+            &["btop".to_string()],
+            &Some(home.clone()),
+        );
+        assert_restore_command(&cmd, &["kitty", "sh", "-c"], "btop");
+    }
+
+    #[test]
+    fn build_restore_wezterm_with_cwd() {
+        let profile = TerminalProfile::Wezterm;
+        let cmd = build_terminal_restore_command(
+            &["wezterm".to_string()],
+            &profile,
+            &["btop".to_string()],
+            &Some("/home/user/projects".to_string()),
+        );
+        assert_restore_command(
+            &cmd,
+            &[
+                "wezterm",
+                "start",
+                "--cwd",
+                "/home/user/projects",
+                "--",
+                "sh",
+                "-c",
+            ],
+            "btop",
+        );
+    }
+
+    #[test]
+    fn build_restore_ghostty_with_cwd() {
+        let profile = TerminalProfile::Ghostty;
+        let cmd = build_terminal_restore_command(
+            &["ghostty".to_string()],
+            &profile,
+            &["btop".to_string()],
+            &Some("/home/user/projects".to_string()),
+        );
+        assert_restore_command(
+            &cmd,
+            &[
+                "ghostty",
+                "--working-directory=/home/user/projects",
+                "-e",
+                "sh",
+                "-c",
+            ],
+            "btop",
+        );
+    }
+
+    #[test]
+    fn build_restore_foot_with_cwd() {
+        let profile = TerminalProfile::Foot;
+        let cmd = build_terminal_restore_command(
+            &["foot".to_string()],
+            &profile,
+            &["btop".to_string()],
+            &Some("/home/user/projects".to_string()),
+        );
+        assert_restore_command(
+            &cmd,
+            &[
+                "foot",
+                "--working-directory",
+                "/home/user/projects",
+                "sh",
+                "-c",
+            ],
+            "btop",
+        );
+    }
+
+    #[test]
+    fn build_restore_alacritty_with_cwd() {
+        let profile = TerminalProfile::Alacritty;
+        let cmd = build_terminal_restore_command(
+            &["alacritty".to_string()],
+            &profile,
+            &["btop".to_string()],
+            &Some("/home/user/projects".to_string()),
+        );
+        assert_restore_command(
+            &cmd,
+            &[
+                "alacritty",
+                "--working-directory",
+                "/home/user/projects",
+                "-e",
+                "sh",
+                "-c",
+            ],
+            "btop",
+        );
+    }
+
+    #[test]
+    fn build_restore_with_shell_metacharacters() {
+        let profile = TerminalProfile::Kitty;
+        let cmd = build_terminal_restore_command(
+            &["kitty".to_string()],
+            &profile,
+            &["echo 'hello'; rm -rf /".to_string()],
+            &None,
+        );
+        assert_eq!(cmd[3], expected_exec_suffix("echo 'hello'; rm -rf /"));
+    }
+
+    #[test]
+    fn build_restore_preserves_multi_arg_command() {
+        let profile = TerminalProfile::Kitty;
+        let cmd = build_terminal_restore_command(
+            &["kitty".to_string()],
+            &profile,
+            &["nvim".to_string(), "/path/to file".to_string()],
+            &None,
+        );
+        let expected_suffix = {
+            let shell = get_restore_shell();
+            format!(
+                "{} {}; exec {}",
+                shell_escape("nvim"),
+                shell_escape("/path/to file"),
+                shell_escape(&shell)
+            )
+        };
+        assert_eq!(cmd[3], expected_suffix);
+    }
+
+    #[test]
+    fn build_restore_preserves_mapped_launch_prefix() {
+        let profile = TerminalProfile::Generic;
+        let cmd = build_terminal_restore_command(
+            &[
+                "flatpak".to_string(),
+                "run".to_string(),
+                "org.myterm".to_string(),
+            ],
+            &profile,
+            &["btop".to_string()],
+            &None,
+        );
+        assert_eq!(cmd[0], "flatpak");
+        assert_eq!(cmd[1], "run");
+        assert_eq!(cmd[2], "org.myterm");
+    }
+
+    #[test]
+    fn build_spawn_command_falls_back_to_mappings() {
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "com.mitchellh.ghostty".to_string(),
+            vec!["ghostty".to_string()],
+        );
+
+        let window = SavedWindow {
+            id: 1,
+            app_id: "com.mitchellh.ghostty".to_string(),
+            workspace_idx: None,
+            workspace_name: None,
+            workspace_output: None,
+            is_focused: false,
+            pid: None,
+            terminal_state: None,
+            workspace_id: None,
+        };
+
+        let cmd = build_spawn_command("com.mitchellh.ghostty", &window, &mappings);
+        assert_eq!(cmd, vec!["ghostty"]);
+    }
+
+    #[test]
+    fn build_spawn_command_uses_terminal_state() {
+        let mappings = HashMap::new();
+        let window = SavedWindow {
+            id: 1,
+            app_id: "kitty".to_string(),
+            workspace_idx: Some(0),
+            workspace_name: None,
+            workspace_output: None,
+            is_focused: true,
+            pid: Some(1234),
+            terminal_state: Some(TerminalState {
+                child_command: Some(ChildCommand::Args(vec!["btop".to_string()])),
+                child_cwd: Some("/home/user".to_string()),
+            }),
+            workspace_id: None,
+        };
+
+        let cmd = build_spawn_command("kitty", &window, &mappings);
+        assert_eq!(cmd[0], "kitty");
+        assert!(cmd.contains(&expected_exec_suffix("btop")));
+    }
+
+    #[test]
+    fn saved_window_deserializes_old_format_with_workspace_id() {
+        let json = r#"{
+            "id": 42,
+            "app_id": "kitty",
+            "workspace_id": 3,
+            "is_focused": true
+        }"#;
+        let w: SavedWindow = serde_json::from_str(json).unwrap();
+        assert_eq!(w.id, 42);
+        assert_eq!(w.app_id, "kitty");
+        assert_eq!(w.workspace_idx, None);
+        assert_eq!(w.workspace_name, None);
+        assert_eq!(w.workspace_output, None);
+        assert!(w.terminal_state.is_none());
+        assert!(w.pid.is_none());
+    }
+
+    #[test]
+    fn saved_window_deserializes_new_format_with_workspace_fields() {
+        let json = r#"{
+            "id": 42,
+            "app_id": "kitty",
+            "workspace_idx": 2,
+            "workspace_name": "dev",
+            "workspace_output": "eDP-1",
+            "is_focused": true,
+            "pid": 1234,
+            "terminal_state": {
+                "child_command": "btop",
+                "child_cwd": "/home/user"
+            }
+        }"#;
+        let w: SavedWindow = serde_json::from_str(json).unwrap();
+        assert_eq!(w.workspace_idx, Some(2));
+        assert_eq!(w.workspace_name, Some("dev".to_string()));
+        assert_eq!(w.workspace_output, Some("eDP-1".to_string()));
+        assert_eq!(w.pid, Some(1234));
+        let ts = w.terminal_state.unwrap();
+        assert_eq!(
+            ts.child_command,
+            Some(ChildCommand::Legacy("btop".to_string()))
+        );
+        assert_eq!(ts.child_cwd, Some("/home/user".to_string()));
+    }
+
+    #[test]
+    fn saved_window_deserializes_v3_array_child_command() {
+        let json = r#"{
+            "id": 42,
+            "app_id": "kitty",
+            "is_focused": true,
+            "pid": 1234,
+            "terminal_state": {
+                "child_command": ["nvim", "/path/to/file"],
+                "child_cwd": "/home/user"
+            }
+        }"#;
+        let w: SavedWindow = serde_json::from_str(json).unwrap();
+        let ts = w.terminal_state.unwrap();
+        assert_eq!(
+            ts.child_command,
+            Some(ChildCommand::Args(vec![
+                "nvim".to_string(),
+                "/path/to/file".to_string()
+            ]))
+        );
+    }
+
+    #[test]
+    fn saved_window_deserializes_minimal() {
+        let json = r#"{"id": 1, "app_id": "firefox", "is_focused": false}"#;
+        let w: SavedWindow = serde_json::from_str(json).unwrap();
+        assert_eq!(w.app_id, "firefox");
+        assert_eq!(w.workspace_idx, None);
+        assert!(w.terminal_state.is_none());
+        assert!(w.pid.is_none());
+    }
+
+    #[test]
+    fn saved_window_detects_legacy_workspace_id() {
+        let json = r#"{
+            "id": 42,
+            "app_id": "kitty",
+            "workspace_id": 3,
+            "is_focused": true
+        }"#;
+        let w: SavedWindow = serde_json::from_str(json).unwrap();
+        assert!(w.workspace_id.is_some());
+        assert!(w.workspace_idx.is_none());
+    }
+
+    #[test]
+    fn config_default_values() {
+        let c = TerminalStateConfig::default();
+        assert!(c.enabled);
+        assert!(c.terminal_app_ids.contains(&"kitty".to_string()));
+        assert!(c.shell_names.contains(&"fish".to_string()));
+        assert!(c.helper_names.contains(&"kitten".to_string()));
+        assert_eq!(c.max_walk_depth, 20);
+    }
+
+    #[test]
+    fn session_data_parses_versioned_format() {
+        let json = r#"{
+            "version": 2,
+            "windows": [
+                {"id": 1, "app_id": "kitty", "is_focused": false}
+            ]
+        }"#;
+        let session: SessionData = serde_json::from_str(json).unwrap();
+        assert!(!session.is_legacy());
+        let windows = session.into_windows();
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].app_id, "kitty");
+    }
+
+    #[test]
+    fn session_data_parses_legacy_array_format() {
+        let json = r#"[
+            {"id": 1, "app_id": "kitty", "is_focused": false},
+            {"id": 2, "app_id": "firefox", "is_focused": true}
+        ]"#;
+        let session: SessionData = serde_json::from_str(json).unwrap();
+        assert!(session.is_legacy());
+        let windows = session.into_windows();
+        assert_eq!(windows.len(), 2);
+    }
+
+    #[test]
+    fn versioned_session_serializes_correctly() {
+        let session = VersionedSession {
+            version: SESSION_FORMAT_VERSION,
+            windows: vec![SavedWindow {
+                id: 42,
+                app_id: "kitty".to_string(),
+                workspace_idx: Some(1),
+                workspace_name: None,
+                workspace_output: None,
+                is_focused: false,
+                pid: Some(1234),
+                terminal_state: Some(TerminalState {
+                    child_command: Some(ChildCommand::Args(vec!["btop".to_string()])),
+                    child_cwd: Some("/home/user".to_string()),
+                }),
+                workspace_id: None,
+            }],
+        };
+        let json = serde_json::to_string_pretty(&session).unwrap();
+        assert!(json.contains("\"version\": 3"));
+        assert!(json.contains("\"windows\""));
+        let parsed: SessionData = serde_json::from_str(&json).unwrap();
+        assert!(!parsed.is_legacy());
+    }
+
+    #[test]
+    fn get_restore_shell_returns_non_empty() {
+        let shell = get_restore_shell();
+        assert!(!shell.is_empty());
+        assert!(shell.contains('/') || shell == "/bin/sh");
+    }
+
+    #[test]
+    fn get_restore_shell_prefers_env_var() {
+        let shell = get_restore_shell();
+        if let Ok(env_shell) = std::env::var("SHELL")
+            && !env_shell.is_empty()
+        {
+            assert_eq!(shell, env_shell);
+        }
+    }
 }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,0 +1,429 @@
+use std::fs;
+use std::path::Path;
+
+#[cfg(target_os = "linux")]
+fn read_cmdline_at(base: &Path, pid: u32) -> Option<Vec<String>> {
+    let path = base.join(pid.to_string()).join("cmdline");
+    let data = fs::read(&path).ok()?;
+    let args: Vec<String> = data
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect();
+    if args.is_empty() { None } else { Some(args) }
+}
+
+#[cfg(target_os = "linux")]
+fn read_cwd_at(base: &Path, pid: u32) -> Option<String> {
+    let path = base.join(pid.to_string()).join("cwd");
+    fs::read_link(&path)
+        .ok()
+        .and_then(|p| p.into_os_string().into_string().ok())
+}
+
+#[cfg(target_os = "linux")]
+fn read_comm_at(base: &Path, pid: u32) -> Option<String> {
+    let path = base.join(pid.to_string()).join("comm");
+    fs::read_to_string(&path).ok().map(|s| s.trim().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn get_children_at(base: &Path, pid: u32) -> Vec<u32> {
+    let path = base
+        .join(pid.to_string())
+        .join("task")
+        .join(pid.to_string())
+        .join("children");
+    fs::read_to_string(&path)
+        .ok()
+        .map(|s| {
+            s.split_whitespace()
+                .filter_map(|p| p.parse::<u32>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn is_shell(comm: &str, shell_names: &[String]) -> bool {
+    shell_names.iter().any(|s| s == comm)
+}
+
+fn is_helper(comm: &str, helper_names: &[String]) -> bool {
+    helper_names.iter().any(|s| s == comm)
+}
+
+#[cfg(target_os = "linux")]
+fn read_stat_field_at(base: &Path, pid: u32, field: usize) -> Option<i64> {
+    let path = base.join(pid.to_string()).join("stat");
+    let data = fs::read_to_string(&path).ok()?;
+
+    let comm_end = data.find(')')?;
+    let after_comm = &data[comm_end + 2..];
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+
+    let idx = field.saturating_sub(3);
+    fields.get(idx).and_then(|f| f.parse::<i64>().ok())
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_child_process_at(
+    base: &Path,
+    pid: u32,
+    shell_names: &[String],
+    helper_names: &[String],
+    max_depth: u32,
+) -> Option<(Vec<String>, String)> {
+    let mut current = pid;
+
+    for depth in 0..max_depth {
+        let proc_path = base.join(current.to_string());
+        if !proc_path.exists() {
+            if depth == 0 {
+                eprintln!("Warning: [proc] PID {} no longer exists in {:?}", pid, base);
+            }
+            break;
+        }
+
+        let children = get_children_at(base, current);
+        let tpgid = read_stat_field_at(base, current, 8).unwrap_or(0) as u32;
+
+        if children.is_empty() {
+            if tpgid > 0
+                && let Some(fg_comm) = read_comm_at(base, tpgid)
+                && !is_shell(&fg_comm, shell_names)
+                && fg_comm != "__atexit__"
+                && !is_helper(&fg_comm, helper_names)
+            {
+                let cmd = read_cmdline_at(base, tpgid).unwrap_or_default();
+                let cwd = read_cwd_at(base, tpgid).unwrap_or_default();
+                return Some((cmd, cwd));
+            }
+            break;
+        }
+
+        // Prefer the foreground child (matching tpgid); fall back to first child.
+        let next_pid = children
+            .iter()
+            .copied()
+            .find(|&c| tpgid > 0 && c == tpgid)
+            .unwrap_or(children[0]);
+
+        let comm = match read_comm_at(base, next_pid) {
+            Some(c) => c,
+            None => {
+                eprintln!(
+                    "Warning: [proc] could not read comm for PID {} (child of {})",
+                    next_pid, current
+                );
+                return None;
+            }
+        };
+
+        if is_shell(&comm, shell_names) || is_helper(&comm, helper_names) {
+            current = next_pid;
+            continue;
+        }
+
+        let cmd = read_cmdline_at(base, next_pid).unwrap_or_default();
+        let cwd = read_cwd_at(base, next_pid).unwrap_or_default();
+        return Some((cmd, cwd));
+    }
+
+    None
+}
+
+#[cfg(target_os = "linux")]
+pub fn resolve_child_process(
+    pid: u32,
+    shell_names: &[String],
+    helper_names: &[String],
+    max_depth: u32,
+) -> Option<(Vec<String>, String)> {
+    resolve_child_process_at(
+        Path::new("/proc"),
+        pid,
+        shell_names,
+        helper_names,
+        max_depth,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn resolve_child_process(
+    _pid: u32,
+    _shell_names: &[String],
+    _helper_names: &[String],
+    _max_depth: u32,
+) -> Option<(Vec<String>, String)> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+
+    fn create_fake_proc_dir(dir: &Path, pid: u32) -> PathBuf {
+        let pid_dir = dir.join(pid.to_string());
+        fs::create_dir_all(&pid_dir).unwrap();
+        let task_dir = pid_dir.join("task").join(pid.to_string());
+        fs::create_dir_all(&task_dir).unwrap();
+        pid_dir
+    }
+
+    fn write_cmdline(dir: &Path, args: &[&str]) {
+        let data: Vec<u8> = args
+            .iter()
+            .flat_map(|a| {
+                let mut bytes = a.as_bytes().to_vec();
+                bytes.push(0);
+                bytes
+            })
+            .collect();
+        fs::write(dir.join("cmdline"), data).unwrap();
+    }
+
+    fn write_comm(dir: &Path, name: &str) {
+        fs::write(dir.join("comm"), format!("{}\n", name)).unwrap();
+    }
+
+    fn write_children(dir: &Path, pids: &[u32]) {
+        let children_path = dir
+            .join("task")
+            .join(dir.file_name().unwrap())
+            .join("children");
+        let content: String = pids.iter().map(|p| format!("{} ", p)).collect();
+        fs::write(children_path, content.trim()).unwrap();
+    }
+
+    #[test]
+    fn resolve_finds_direct_child() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let fish_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&fish_dir, &["fish"]);
+        write_comm(&fish_dir, "fish");
+        write_children(&fish_dir, &[1002]);
+
+        let btop_dir = create_fake_proc_dir(tmp.path(), 1002);
+        write_cmdline(&btop_dir, &["btop"]);
+        write_comm(&btop_dir, "btop");
+        symlink("/home/user", btop_dir.join("cwd")).unwrap();
+        write_children(&btop_dir, &[]);
+
+        let shell_names = vec!["fish".to_string(), "bash".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert_eq!(
+            result,
+            Some((vec!["btop".to_string()], "/home/user".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_skips_shell_and_finds_grandchild() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let bash_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&bash_dir, &["bash"]);
+        write_comm(&bash_dir, "bash");
+        write_children(&bash_dir, &[1002]);
+
+        let nvim_dir = create_fake_proc_dir(tmp.path(), 1002);
+        write_cmdline(&nvim_dir, &["nvim", "/path/to/file"]);
+        write_comm(&nvim_dir, "nvim");
+        symlink("/home/user/projects", nvim_dir.join("cwd")).unwrap();
+        write_children(&nvim_dir, &[]);
+
+        let shell_names = vec!["bash".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert_eq!(
+            result,
+            Some((
+                vec!["nvim".to_string(), "/path/to/file".to_string()],
+                "/home/user/projects".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn resolve_skips_helpers() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let kitten_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&kitten_dir, &["kitten", "@", "ssh"]);
+        write_comm(&kitten_dir, "kitten");
+        write_children(&kitten_dir, &[1002]);
+
+        let btop_dir = create_fake_proc_dir(tmp.path(), 1002);
+        write_cmdline(&btop_dir, &["btop"]);
+        write_comm(&btop_dir, "btop");
+        symlink("/home/user", btop_dir.join("cwd")).unwrap();
+        write_children(&btop_dir, &[]);
+
+        let shell_names: Vec<String> = vec![];
+        let helper_names = vec!["kitten".to_string()];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert_eq!(
+            result,
+            Some((vec!["btop".to_string()], "/home/user".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_returns_none_when_only_shell() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let fish_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&fish_dir, &["fish"]);
+        write_comm(&fish_dir, "fish");
+        write_children(&fish_dir, &[]);
+
+        let shell_names = vec!["fish".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_returns_none_when_pid_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let shell_names = vec!["fish".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 9999, &shell_names, &helper_names, 20);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_filters_atexit() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let fish_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&fish_dir, &["fish"]);
+        write_comm(&fish_dir, "fish");
+        write_children(&fish_dir, &[]);
+
+        let atexit_stat = "1001 (fish) S 0 0 0 0 -1 1002\n";
+        fs::write(fish_dir.join("stat"), atexit_stat).unwrap();
+
+        let atexit_dir = create_fake_proc_dir(tmp.path(), 1002);
+        write_cmdline(&atexit_dir, &["__atexit__"]);
+        write_comm(&atexit_dir, "__atexit__");
+        symlink("/home/user", atexit_dir.join("cwd")).unwrap();
+
+        let shell_names = vec!["fish".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_uses_tpgid_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let fish_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&fish_dir, &["fish"]);
+        write_comm(&fish_dir, "fish");
+        write_children(&fish_dir, &[]);
+
+        let stat_content = "1001 (fish) S 0 0 0 0 2000\n";
+        fs::write(fish_dir.join("stat"), stat_content).unwrap();
+
+        let btop_dir = create_fake_proc_dir(tmp.path(), 2000);
+        write_cmdline(&btop_dir, &["btop"]);
+        write_comm(&btop_dir, "btop");
+        symlink("/home/user", btop_dir.join("cwd")).unwrap();
+
+        let shell_names = vec!["fish".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert_eq!(
+            result,
+            Some((vec!["btop".to_string()], "/home/user".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_foreground_child_over_first_child() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let kitty_dir = create_fake_proc_dir(tmp.path(), 1000);
+        write_cmdline(&kitty_dir, &["kitty"]);
+        write_comm(&kitty_dir, "kitty");
+        write_children(&kitty_dir, &[1001]);
+
+        let fish_dir = create_fake_proc_dir(tmp.path(), 1001);
+        write_cmdline(&fish_dir, &["fish"]);
+        write_comm(&fish_dir, "fish");
+        write_children(&fish_dir, &[1002, 1003]);
+        // tpgid (field 8) points to 1003 = the foreground process
+        fs::write(fish_dir.join("stat"), "1001 (fish) S 0 0 0 0 1003\n").unwrap();
+
+        let htop_dir = create_fake_proc_dir(tmp.path(), 1002);
+        write_cmdline(&htop_dir, &["htop"]);
+        write_comm(&htop_dir, "htop");
+
+        let btop_dir = create_fake_proc_dir(tmp.path(), 1003);
+        write_cmdline(&btop_dir, &["btop"]);
+        write_comm(&btop_dir, "btop");
+        symlink("/home/user", btop_dir.join("cwd")).unwrap();
+
+        let shell_names = vec!["fish".to_string()];
+        let helper_names: Vec<String> = vec![];
+        let result = resolve_child_process_at(tmp.path(), 1000, &shell_names, &helper_names, 20);
+        assert_eq!(
+            result,
+            Some((vec!["btop".to_string()], "/home/user".to_string()))
+        );
+    }
+
+    #[test]
+    fn is_shell_detection() {
+        let shells = vec!["fish".to_string(), "bash".to_string(), "-fish".to_string()];
+        assert!(is_shell("fish", &shells));
+        assert!(is_shell("-fish", &shells));
+        assert!(!is_shell("btop", &shells));
+        assert!(!is_shell("nvim", &shells));
+    }
+
+    #[test]
+    fn is_helper_detection() {
+        let helpers = vec!["kitten".to_string()];
+        assert!(is_helper("kitten", &helpers));
+        assert!(!is_helper("btop", &helpers));
+    }
+}


### PR DESCRIPTION
Restores the command that was running **inside** a terminal when a session is restored, instead of always opening a bare shell.

## Why
Session restore previously spawned terminals by `app_id` only (e.g. `kitty`), discarding the foreground process — so `btop`, `nvim`, an `ssh` session, or a running build vanished on restart, defeating session recovery. The niri IPC `Window` already exposes a `pid`; this PR puts it to use.

## What
- **`/proc` process-tree walk** (`src/proc.rs`): descend from a terminal's `pid` to the foreground child, skipping shells and helpers, resolving both command and cwd (depth-capped). Prefers the `tpgid`-matching child when a shell has multiple children.
- **Argv preservation**: the cmdline is kept as `Vec<String>` end-to-end and each argument is shell-escaped individually — so multi-argument commands (`nvim file`, `ssh host`) restore correctly instead of being treated as a single executable name.
- **Versioned session format** (v3): richer `SavedWindow` carrying `pid`, workspace fields, and optional `terminal_state` (argv array + cwd). Legacy v2 string sessions migrate transparently via an untagged serde enum.
- **Data-driven terminal profiles** (kitty, foot, wezterm, ghostty, alacritty): an enum with a typed `CwdFlag`, so impossible flag combinations are unrepresentable. Multi-argument app mappings launch with the full command vector.
- **Race-free restore**: a shared claimed-ID set ensures parallel restores of the same `app_id` no longer target the same spawned window.
- **Hardening**: `spawn_blocking`, shell-escaping, shell fallback (`$SHELL`→passwd→`sh`), error logging that never aborts a save/restore.

## Notes
No behavior change when `terminal_state.enabled = false`. README docs + example added.

Assisted-by: GLM-5.1 and GLM-5.2 via Crush